### PR TITLE
Resolve FFI deprecation warning

### DIFF
--- a/lib/rbnacl/hmac/sha256.rb
+++ b/lib/rbnacl/hmac/sha256.rb
@@ -89,21 +89,21 @@ module RbNaCl
         compute_authenticator(correct, message)
         Util.verify32(correct, authenticator)
       end
-    end
 
-    # The crypto_auth_hmacsha256_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
-    class SHA256State < FFI::Struct
-      layout :state, [:uint32, 8],
-             :count, :uint64,
-             :buf, [:uint8, 64]
-    end
+      # The crypto_auth_hmacsha256_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha256.h
+      class SHA256State < FFI::Struct
+        layout :state, [:uint32, 8],
+               :count, :uint64,
+               :buf, [:uint8, 64]
+      end
 
-    # The crypto_hash_sha256_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha256.h
-    class State < FFI::Struct
-      layout :ictx, SHA256State,
-             :octx, SHA256State
+      # The crypto_hash_sha256_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha256.h
+      class State < FFI::Struct
+        layout :ictx, SHA256State,
+               :octx, SHA256State
+      end
     end
   end
 end

--- a/lib/rbnacl/hmac/sha512.rb
+++ b/lib/rbnacl/hmac/sha512.rb
@@ -89,21 +89,21 @@ module RbNaCl
         compute_authenticator(correct, message)
         Util.verify64(correct, authenticator)
       end
-    end
 
-    # The crypto_auth_hmacsha512_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha512.h
-    class SHA512State < FFI::Struct
-      layout :state, [:uint64, 8],
-             :count, [:uint64, 2],
-             :buf, [:uint8, 128]
-    end
+      # The crypto_auth_hmacsha512_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha512.h
+      class SHA512State < FFI::Struct
+        layout :state, [:uint64, 8],
+               :count, [:uint64, 2],
+               :buf, [:uint8, 128]
+      end
 
-    # The crypto_hash_sha512_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha512.h
-    class State < FFI::Struct
-      layout :ictx, SHA512State,
-             :octx, SHA512State
+      # The crypto_hash_sha512_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha512.h
+      class State < FFI::Struct
+        layout :ictx, SHA512State,
+               :octx, SHA512State
+      end
     end
   end
 end

--- a/lib/rbnacl/hmac/sha512256.rb
+++ b/lib/rbnacl/hmac/sha512256.rb
@@ -87,21 +87,21 @@ module RbNaCl
         compute_authenticator(correct, message)
         Util.verify32(correct, authenticator)
       end
-    end
 
-    # The crypto_auth_hmacsha512256_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
-    class SHA512256State < FFI::Struct
-      layout :state, [:uint64, 8],
-             :count, [:uint64, 2],
-             :buf, [:uint8, 128]
-    end
+      # The crypto_auth_hmacsha512256_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_auth_hmacsha512256.h
+      class SHA512256State < FFI::Struct
+        layout :state, [:uint64, 8],
+               :count, [:uint64, 2],
+               :buf, [:uint8, 128]
+      end
 
-    # The crypto_hash_sha512_state struct representation
-    # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha512.h
-    class State < FFI::Struct
-      layout :ictx, SHA512256State,
-             :octx, SHA512256State
+      # The crypto_hash_sha512_state struct representation
+      # ref: jedisct1/libsodium/src/libsodium/include/sodium/crypto_hash_sha512.h
+      class State < FFI::Struct
+        layout :ictx, SHA512256State,
+               :octx, SHA512256State
+      end
     end
   end
 end


### PR DESCRIPTION
When running with ffi-1.2 the following warning is produced.

    [DEPRECATION] Struct layout is already defined for class RbNaCl::HMAC::State. Redefinition as in /bundle/ruby/2.5.0/gems/rbnacl-7.1.0/lib/rbnacl/hmac/sha512256.rb:103:in `<class:State>' will be disallowed in ffi-2.0.

It seems these three files each define a `RbNaCl::HMAC::State` class.

The proposal presented here, nests the classes inside the main class of the file. Hence, three separate classes `RbNaCl::HMAC::SHA256::State`, `RbNaCl::HMAC::SHA512::State`, and `RbNaCl::HMAC::SHA512256::State` are defined instead.


Fixes #205