### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/rbnacl.gemspec
+++ b/rbnacl.gemspec
@@ -9,13 +9,20 @@ Gem::Specification.new do |spec|
   spec.version       = RbNaCl::VERSION
   spec.authors       = ["Tony Arcieri", "Jonathan Stott"]
   spec.email         = ["bascule@gmail.com", "jonathan.stott@gmail.com"]
-  spec.homepage      = "https://github.com/crypto-rb/rbnacl"
+  spec.homepage      = "https://github.com/RubyCrypto/rbnacl"
   spec.licenses      = ["MIT"]
   spec.summary       = "Ruby binding to the libsodium/NaCl cryptography library"
   spec.description   = <<-DESCRIPTION.strip.gsub(/\s+/, " ")
     The Networking and Cryptography (NaCl) library provides a high-level toolkit for building
     cryptographic systems and protocols
   DESCRIPTION
+  spec.metadata = {
+    "bug_tracker_uri" => "#{spec.homepage}/issues",
+    "changelog_uri" => "#{spec.homepage}/blob/master/CHANGES.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/#{spec.name}/#{spec.version}",
+    "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}",
+    "wiki_uri" => "#{spec.homepage}/wiki"
+  }
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `source_code_uri`, and `wiki_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/rbnacl), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.