### PR TITLE
Fix error message generation when empty hmac key is given

### DIFF
--- a/lib/rbnacl/util.rb
+++ b/lib/rbnacl/util.rb
@@ -137,14 +137,15 @@ module RbNaCl
     # @raise [RbNaCl::LengthError] If the string is empty
     #
     # @param string [#to_str] The input string
-    def check_hmac_key(string, _description)
+    # @param description [String] Description of the string (used in the error)
+    def check_hmac_key(string, description)
       check_string_validation(string)
 
       string = string.to_str
 
       if string.bytesize.zero?
         raise LengthError,
-              "#{Description} was #{string.bytesize} bytes (Expected more than 0)",
+              "#{description} was #{string.bytesize} bytes (Expected more than 0)",
               caller
       end
 

--- a/spec/shared/hmac.rb
+++ b/spec/shared/hmac.rb
@@ -6,6 +6,10 @@ RSpec.shared_examples "HMAC" do
     it "raises EncodingError on a key with wrong encoding" do
       expect { described_class.new(wrong_key) }.to raise_error(EncodingError)
     end
+
+    it "raises LengthError when key is zero bytes" do
+      expect { described_class.new("") }.to raise_error(::RbNaCl::LengthError)
+    end
   end
 
   context ".auth" do


### PR DESCRIPTION
Noticed this little issue when empty keys are passed to the hmac algorithms.