### PR TITLE
Allow sodium path to be specified by environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ portmaster or portupgrade), or use make as follows:
 
     cd /usr/ports/security/libsodium; make install clean
 
+You can specify an absolute path to the libsodium library via an environment
+variable:
+
+    export RBNACL_LIBSODIUM_PATH=/path/to/libsodium.so
+
 ### RbNaCl gem
 
 Once you have libsodium installed, add this line to your application's Gemfile:

--- a/lib/rbnacl/init.rb
+++ b/lib/rbnacl/init.rb
@@ -5,7 +5,14 @@ module RbNaCl
   # Defines the libsodium init function
   module Init
     extend FFI::Library
-    ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
+
+    sodium_paths = ["sodium", "libsodium.so.18", "libsodium.so.23"]
+
+    if ENV["RBNACL_LIBSODIUM_PATH"]
+      sodium_paths.prepend(ENV["RBNACL_LIBSODIUM_PATH"])
+    end
+
+    ffi_lib sodium_paths
 
     attach_function :sodium_init, [], :int
   end

--- a/lib/rbnacl/sodium.rb
+++ b/lib/rbnacl/sodium.rb
@@ -8,7 +8,14 @@ module RbNaCl
   module Sodium
     def self.extended(klass)
       klass.extend FFI::Library
-      klass.ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
+
+      sodium_paths = ["sodium", "libsodium.so.18", "libsodium.so.23"]
+
+      if ENV["RBNACL_LIBSODIUM_PATH"]
+        sodium_paths.prepend(ENV["RBNACL_LIBSODIUM_PATH"])
+      end
+
+      klass.ffi_lib sodium_paths
     end
 
     def sodium_type(type = nil)


### PR DESCRIPTION
The main use case is to make working with nix easier, I'd like to package a ruby app and pin the libsodium dependency to one provided by nix.