### PR TITLE
Use libsodium constants for scrypt params

### DIFF
--- a/lib/rbnacl/password_hash.rb
+++ b/lib/rbnacl/password_hash.rb
@@ -32,7 +32,8 @@ module RbNaCl
     # @raise [CryptoError] If calculating the digest fails for some reason.
     #
     # @return [String] The scrypt digest as raw bytes
-    def self.scrypt(password, salt, opslimit = SCrypt::OPSLIMIT_SENSITIVE, memlimit = SCrypt::MEMLIMIT_SENSITIVE, digest_size = 64)
+    def self.scrypt(password, salt, opslimit = SCrypt::OPSLIMIT_SENSITIVE, memlimit = SCrypt::MEMLIMIT_SENSITIVE,
+                    digest_size = 64)
       SCrypt.new(opslimit, memlimit, digest_size).digest(password, salt)
     end
 

--- a/lib/rbnacl/password_hash.rb
+++ b/lib/rbnacl/password_hash.rb
@@ -32,7 +32,7 @@ module RbNaCl
     # @raise [CryptoError] If calculating the digest fails for some reason.
     #
     # @return [String] The scrypt digest as raw bytes
-    def self.scrypt(password, salt, opslimit, memlimit, digest_size = 64)
+    def self.scrypt(password, salt, opslimit = SCrypt::OPSLIMIT_SENSITIVE, memlimit = SCrypt::MEMLIMIT_SENSITIVE, digest_size = 64)
       SCrypt.new(opslimit, memlimit, digest_size).digest(password, salt)
     end
 

--- a/lib/rbnacl/password_hash/scrypt.rb
+++ b/lib/rbnacl/password_hash/scrypt.rb
@@ -23,6 +23,8 @@ module RbNaCl
       sodium_primitive :scryptsalsa208sha256
 
       sodium_constant :SALTBYTES
+      sodium_constant :OPSLIMIT_SENSITIVE
+      sodium_constant :MEMLIMIT_SENSITIVE
 
       sodium_function :scrypt,
                       :crypto_pwhash_scryptsalsa208sha256,

--- a/lib/rbnacl/test_vectors.rb
+++ b/lib/rbnacl/test_vectors.rb
@@ -120,10 +120,10 @@ module RbNaCl
                      "82ad86b83c8f20a23dbb74f6da60b0b6ecffd67134d45946ac8ebfb3064294bc" \
                      "097d43ced68642bfb8bbbdd0f50b30118f5e",
     scrypt_salt: "39d82eef32010b8b79cc5ba88ed539fbaba741100f2edbeca7cc171ffeabf258",
-    scrypt_opslimit: 758_010,
-    scrypt_memlimit: 5_432_947,
-    scrypt_digest: "bcc5c2fd785e4781d1201ed43d84925537e2a540d3de55f5812f29e9dd0a4a00" \
-                     "451a5c8ddbb4862c03d45c75bf91b7fb49265feb667ad5c899fdbf2ca19eac67",
+    scrypt_opslimit: 33_554_432,
+    scrypt_memlimit: 1_073_741_824,
+    scrypt_digest: "11a4c60b98411758ba9e89a28587c074ae674c367326c79a999e415110b14460" \
+                   "5921bd3c897098a837fa40d9eef5338268754ea5e243f630a58fa698df95d1ed",
 
     # argon2 vectors
     # from libsodium/test/default/pwhash_argon2i.c

--- a/spec/rbnacl/password_hash/scrypt_spec.rb
+++ b/spec/rbnacl/password_hash/scrypt_spec.rb
@@ -18,4 +18,13 @@ RSpec.describe RbNaCl::PasswordHash::SCrypt do
 
     expect(digest).to eq reference_digest
   end
+
+  it "calculates the correct digest using libsodium primitives" do
+    digest = RbNaCl::PasswordHash.scrypt(
+      reference_password,
+      reference_salt
+    )
+
+    expect(digest).to eq reference_digest
+  end
 end


### PR DESCRIPTION
This pull request adds two libsodium constants `OPSLIMIT_SENSITIVE` and `MEMLIMIT_SENSITIVE` as default values for the `opslimit` and `memlimit` parameters to `RbNaCl::PasswordHash.scrypt`.

Here is an example of these values being used in the wild: https://github.com/jedisct1/minisign/blob/573988d2355172b6e050fa3fdc974abd3e476988/src/minisign.c#L357-L358 

Also for the test case, I updated the expected digest so that there wouldn't be two `scrypt_digest`s.