### PR TITLE
Support alpine 3.19 and up

### DIFF
--- a/lib/rbnacl/init.rb
+++ b/lib/rbnacl/init.rb
@@ -5,7 +5,7 @@ module RbNaCl
   # Defines the libsodium init function
   module Init
     extend FFI::Library
-    ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
+    ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23", "libsodium.so.26"]
 
     attach_function :sodium_init, [], :int
   end

--- a/lib/rbnacl/sodium.rb
+++ b/lib/rbnacl/sodium.rb
@@ -8,7 +8,7 @@ module RbNaCl
   module Sodium
     def self.extended(klass)
       klass.extend FFI::Library
-      klass.ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23"]
+      klass.ffi_lib ["sodium", "libsodium.so.18", "libsodium.so.23", "libsodium.so.26"]
     end
 
     def sodium_type(type = nil)


### PR DESCRIPTION
## Context

We use RbNaCl with Alpine 3.19 and we see the below errors

```
#40 7.090 Could not open library 'libsodium.so': Error loading shared library libsodium.so: No such file or directory.

#40 7.090 Could not open library 'libsodium.so.18': Error loading shared library libsodium.so.18: No such file or directory.

#40 7.090 Could not open library 'libsodium.so.23': Error loading shared library libsodium.so.23: No such file or directory.
```

After looking into [the content of Alpine](https://pkgs.alpinelinux.org/contents?file=&path=&name=libsodium&branch=edge&repo=main&arch=aarch64), it looks like the file is now `libsodium.so.26`.