### PR TITLE
Add Ruby 3.3 to the test matrix and update the checkout Github Action to the latest version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,12 @@ jobs:
           - ruby-3.0
           - ruby-3.1
           - ruby-3.2
+          - ruby-3.3
           - jruby-9.3.0
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
@@ -34,7 +35,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ versions:
 * Ruby 3.0
 * Ruby 3.1
 * Ruby 3.2
+* Ruby 3.3
 * JRuby 9.3
 
 If something doesn't work on one of these versions, it's a bug.


### PR DESCRIPTION
Add Ruby 3.3 to the CI Ruby version matrix to test against the current stable release of Ruby. Also update the `actions/checkout` GitHub Action to the current latest version.