### PR TITLE
Add automatic DLL support for Windows Ruby Installer

### DIFF
--- a/rbnacl.gemspec
+++ b/rbnacl.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
     "changelog_uri" => "#{spec.homepage}/blob/master/CHANGES.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/#{spec.name}/#{spec.version}",
     "source_code_uri" => "#{spec.homepage}/tree/v#{spec.version}",
-    "wiki_uri" => "#{spec.homepage}/wiki"
+    "wiki_uri" => "#{spec.homepage}/wiki",
+    "msys2_mingw_dependencies" => "libsodium"
   }
   spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR).reject do |f|
     f.start_with?("images/", "spec/", "tasks/", "Rakefile")


### PR DESCRIPTION
This PR uses the Gemspec `msys2_mingw_dependencies` metadata to automatically install the appropriate Mingw package. You can see the same thing is used for the [Psych gem here](https://github.com/ruby/psych/blob/master/psych.gemspec#L80).

This saves Windows users the trouble of downloading/renaming the DLL file.

You can see [here](https://packages.msys2.org/packages/mingw-w64-ucrt-x86_64-libsodium) the file is located at `
/ucrt64/bin/libsodium-26.dll` on the Mingw package.

TODO: Update readme
TODO: Update windows tests
